### PR TITLE
Update GitHub Actions workflow for tagging and publishing

### DIFF
--- a/.github/workflows/tag_and_publish.yml
+++ b/.github/workflows/tag_and_publish.yml
@@ -62,9 +62,9 @@ jobs:
         add: '["README.md"]'
   tag:
     needs: update_badges
-    uses: AllenNeuralDynamics/aind-github-actions/.github/workflows/tag.yml@main
+    uses: AllenNeuralDynamics/.github/.github/workflows/release-bump-version.yml@main
     secrets:
-      SERVICE_TOKEN: ${{ secrets.SERVICE_TOKEN }}
+      repo-token: ${{ secrets.SERVICE_TOKEN }}
   publish:
     needs: tag
     if: false


### PR DESCRIPTION
## Summary
We are deprecating AllenNeuralDynamics/aind-github-actions repo and are in the process of migrating to a new workflow. This PR updates the tag workflow references that point to the old workflow.

## Changes
- Updated workflow references from AllenNeuralDynamics/aind-github-actions/.github/workflows/tag.yml@main to AllenNeuralDynamics/.github/.github/workflows/release-bump-version.yml@main.
- Updated SERVICE_TOKEN to repo-token.